### PR TITLE
Error reporting improvements

### DIFF
--- a/src/rdf_validator/core.clj
+++ b/src/rdf_validator/core.clj
@@ -68,7 +68,7 @@
           failed (pos? (count results))]
       {:test-source test-source
        :result      (if failed :failed :passed)
-       :errors      (mapv str results)})))
+       :errors results})))
 
 (defn run-test-case [test-case query-variables endpoint]
   (let [source (:source test-case)]

--- a/src/rdf_validator/core.clj
+++ b/src/rdf_validator/core.clj
@@ -71,21 +71,23 @@
        :errors      (mapv str results)})))
 
 (defn run-test-case [test-case query-variables endpoint]
-  (try
-    (let [source (:source test-case)
-          ^String sparql-str (load-sparql-template source query-variables)
-          query (QueryFactory/create sparql-str Syntax/syntaxSPARQL_11)
-          test {:test-source source :query-string sparql-str}]
-      (cond
-        (.isAskType query) (run-sparql-ask-test test endpoint)
-        (.isSelectType query) (run-sparql-select-test test endpoint)
-        :else {:test-case test-case
-               :result :ignored
-               :errors []}))
-    (catch Exception ex
-      {:test-case test-case
-       :result :errored
-       :errors [(.getMessage ex)]})))
+  (let [source (:source test-case)]
+    (try
+      (let [^String sparql-str (load-sparql-template source query-variables)
+            query (QueryFactory/create sparql-str Syntax/syntaxSPARQL_11)
+            test {:test-source source :query-string sparql-str}]
+        (cond
+          (.isAskType query) (run-sparql-ask-test test endpoint)
+          (.isSelectType query) (run-sparql-select-test test endpoint)
+          :else {:test-source source
+                 :test-case test-case
+                 :result :ignored
+                 :errors []}))
+      (catch Exception ex
+        {:test-source source
+         :test-case test-case
+         :result :errored
+         :errors [(.getMessage ex)]}))))
 
 (defn run-test-cases [test-cases query-variables endpoint]
   (map #(run-test-case % query-variables endpoint) test-cases))

--- a/src/rdf_validator/reporting.clj
+++ b/src/rdf_validator/reporting.clj
@@ -1,7 +1,8 @@
 (ns rdf-validator.reporting
   "Used for creating reports of test executions."
   (:require [clojure.string :as string]
-            [rdf-validator.util :as util]))
+            [rdf-validator.util :as util]
+            [clojure.pprint :as pp]))
 
 (defprotocol TestReporter
   (report-test-result! [this test-result]
@@ -13,12 +14,14 @@
   TestReporter
   (report-test-result! [_this {:keys [number test-source result errors] :as test-result}]
     (println (format "%d %s: %s" number (util/get-path test-source) (string/upper-case (name result))))
-    (doseq [error errors]
-      (println (format "\t%s" error)))
+    (when (seq errors)
+      (if (map? (first errors))
+        (pp/print-table errors)
+        (doseq [error errors]
+          (println (format "\t%s" error)))))
     (when (pos? (count errors))
       (println)))
 
   (report-test-summary! [_this {:keys [passed failed errored ignored] :as test-summary}]
     (println)
     (println (format "Passed %d Failed %d Errored %d Ignored %d" passed failed errored ignored))))
-


### PR DESCRIPTION
- Fixes #40 where non-validation errors (e.g. timeouts) would error whilst trying to report the error.

- Small improvement to pretty print errors as a table when possible.

e.g.

```
14 /Users/rick/repos/pmd-rdf-validations/pmd4/src/swirrl/validations/pmd4/SELECT_DatasetExactlyOneGraph.sparql: FAILED

| :count |                                                 :dataset |
|--------+----------------------------------------------------------|
|      9 |                       http://muttnik.gov/data/animals-ds |
|      2 |                       http://muttnik.gov/data/country-ds |
|      2 | http://muttnik.gov/data/two-dims-multigraph/observations |

```

It would be nice to improve these tables so the column order is the same as in the select query, however that is likely quite involved.