### PR TITLE
If the endpoint is a directory, recurse into subdirectories

### DIFF
--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-clojure -A:dev -m kaocha.runner "$@"
+clojure -M:dev -m kaocha.runner "$@"

--- a/src/rdf_validator/core.clj
+++ b/src/rdf_validator/core.clj
@@ -113,7 +113,7 @@
                  ;;TODO: check file exists
                  true) "File does not exist"]
     :assoc-fn conj-in]
-   ["-e" "--endpoint ENDPOINT" "SPARQL data endpoint to validate"
+   ["-e" "--endpoint ENDPOINT" "SPARQL endpoint or RDF file/ directory to validate"
     :parse-fn endpoint/parse-repository]
    ["-g" "--graph GRAPH" "Graph to include in the RDF dataset"
     :default []

--- a/src/rdf_validator/endpoint.clj
+++ b/src/rdf_validator/endpoint.clj
@@ -2,10 +2,14 @@
   (:require [grafter-2.rdf4j.repository :as repo]
             [grafter-2.rdf4j.io :as rdf]
             [grafter-2.rdf.protocols :as pr]
+            [grafter-2.rdf4j.formats :as formats]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log])
   (:import [java.net URISyntaxException URI]
            [java.io File]))
+
+(defn supported-file? [f]
+  (boolean (formats/filename->rdf-format f)))
 
 (defn file->repository [^File f]
   (if (.isDirectory f)
@@ -17,7 +21,8 @@
             (if (.isDirectory file)
               (recur (concat files (.listFiles file)))
               (do
-                (pr/add conn (rdf/statements file))
+                (if (supported-file? file)
+                  (pr/add conn (rdf/statements file)))
                 (recur files))))))
       r)
     (do

--- a/src/rdf_validator/endpoint.clj
+++ b/src/rdf_validator/endpoint.clj
@@ -12,8 +12,13 @@
     (let [r (repo/sail-repo)]
       (with-open [conn (repo/->connection r)]
         (log/info "Creating repository from directory: " (.getAbsolutePath f))
-        (doseq [df (.listFiles f)]
-          (pr/add conn (rdf/statements df))))
+        (loop [[file & files] (.listFiles f)]
+          (when file
+            (if (.isDirectory file)
+              (recur (concat files (.listFiles file)))
+              (do
+                (pr/add conn (rdf/statements file))
+                (recur files))))))
       r)
     (do
       (log/info "Creating repository from file: " (.getAbsolutePath f))

--- a/test/data/test-dir/sub-dir/test3.ttl
+++ b/test/data/test-dir/sub-dir/test3.ttl
@@ -1,0 +1,1 @@
+<http://subject1> <http://schema.org/name> "Subject One" .

--- a/test/rdf_validator/endpoint_test.clj
+++ b/test/rdf_validator/endpoint_test.clj
@@ -21,7 +21,7 @@
 (deftest parse-repository-directory-test
   (let [dir-str "test/data/test-dir"
         repo (parse-repository dir-str)]
-    (is (= 2 (count (with-open [conn (repo/->connection repo)]
+    (is (= 3 (count (with-open [conn (repo/->connection repo)]
                       (into [] (rdf/statements conn))))))))
 
 (deftest parse-repository-file-name-test


### PR DESCRIPTION
To find RDF files.

Otherwise the validator fails as it tries to load a directory as an RDF file.

This should be useful for validating ons-geo-graft.