### PR TITLE
Reorganise readme for non-clojurians

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A Simple runner for RDF test cases & validations.
 
-RDF Validator runs a collection of test cases against a SPARQL endpoint. The endpoint can be either a HTTP(s) SPARQL
-endpoint or a file or directory of RDF files on disk. Test cases can be specified as either a SPARQL query file containing either
+RDF Validator runs a collection of test cases against a SPARQL endpoint. The endpoint can be either a HTTP(s) SPARQL endpoint or a file or directory of RDF files on disk. Test cases can be specified as either a SPARQL query file containing either
 an `ASK` or a `SELECT` query, or a suite of such files with a suite manifest.
 
 Main features:
@@ -14,161 +13,118 @@ Main features:
 - 🏃🏾 Run validations against SPARQL endpoints or files of RDF
 - 🚴 Optionally dynamically generate queries with handlebars-like [selmer](https://github.com/yogthos/Selmer) templates
 
-## Quick Start
+## Quick start
 
-The recomended way to install and run the RDF Validator as an application is via the Clojure command line tools.
+The quickest way to get started is to use the Swirrl's [PMD RDF data validations](https://github.com/Swirrl/pmd-rdf-validations) project which builds upon this application.
 
-The advantage to this method is that it provides an advanced way to include suites of validations as git deps, that
-will be automatically fetched and installed on first usage, and cached thereafter.  This means you can use Clojure's
-`deps.edn` file to fetch suites of validations from 3rd parties easily.
+This readme explains how to customise and develop your own validation suite.
 
-To do this follow these steps:
+## Installing and running the RDF Validator
 
-First [Install the clojure CLI tools](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools).
+The recommended way to use the RDF Validator is as a Clojure application (although you could [compile a jar](/docs/COMPILING.md) instead) which will allow you to include suites of validations from git that will be automatically fetched and installed on first usage, and cached thereafter.
 
-Then specify a `deps.edn` file like this:
+You'll first need to install the [Clojure command line tools](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools).
 
-```clojure
-{
- :aliases {:rdf-validator {:extra-deps { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
-                                                               :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
-                           :main-opts ["-m" "rdf-validator.core"]}
-                           }
- }
-```
-
-This then lets you run the command line validator like so:
-
-    $ clojure -A:rdf-validator <ARGS>
-
-You'll then want to configure some validation suites and supply it with the location of some RDF (either via a SPARQL endpoint) or as a file of triples.
-
-### Including a test suite
-
-The easiest way to include a test suite is to include an existing one as a dependency in your `deps.edn`.  `deps.edn` supports
-[various ways of fetching and resolving dependencies](https://clojure.org/reference/deps_and_cli#_dependencies) and putting them
-on the classpath, such as via git deps, maven packaged jars, or just dependencies at a `:local/root`.
-
-To do this we can include a 3rd party suite [such as those found in this repo](https://github.com/Swirrl/pmd-rdf-validations) like this:
+Once clojure is installed you can create a new directory and add a `deps.edn` file declaring a dependency on the `swirrl/rdf-validator` application:
 
 ```clojure
- {:deps {;; NOTE each dep here is a validation suite
-         swirrl/validations.qb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
-                                :sha "63479f200a7c3d1b0e63bc43b2617181644c846b"
-                                :deps/manifest :deps
-                                :deps/root "qb"}
-        }
- :aliases {:rdf-validator {:extra-deps { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
-                                                               :sha "c85338c44be9f7f9726c30dca4aa47ef8bd9cfe6"}}
-                           :main-opts ["-m" "rdf-validator.core"]}
-                     }
- }
+{:aliases
+ {:rdf-validator
+  {:extra-deps
+   { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
+						   :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
+   :main-opts ["-m" "rdf-validator.core"]}}}
 ```
 
-This particular repository contains multiple suites, each defined as their own dep within the same repo.  The `:deps/root` key essentially
-lets us point to a directory containing a dep, here the dep is a copy of the [integrity constraints](https://www.w3.org/TR/vocab-data-cube/#wf-rules)
-from the [RDF Data Vocabulary](https://www.w3.org/TR/vocab-data-cube/).
+The clojure cli tool will fetch the application (so you won't need to `git clone` this repository) when you run it with the above `:rdf-validator` alias.
+
+For example, to run a sparql test against a remote endpoint you can do:
+
+	$ clojure -M:rdf-validator --suite mytest.sparql --endpoint http://my/sparql/endpoint
+
+You can also have the validator load-up an in-memory sparql endpoint from a RDF file:
+
+	$ clojure -M:rdf-validator --suite mytest.sparql --endpoint mycube.ttl
+
+Or by recursing through a directory tree of RDF files:
+
+	$ clojure -M:rdf-validator --suite mytest.sparql --endpoint /path/to/rdf
+
+You can see more examples in the docs on [command-line usage](/docs/USAGE.md).
+
+## SPARQL validations
+
+Validations are written as SPARQL queries. We recommend that you write `SELECT` queries that will identify and describe the causes of validation failures. The docs explain more about [writing test cases](/docs/WRITING_TEST_CASES.md).
+
+You can pass your `.sparql` files to the validator with a command-line option (here validating a file of RDF data):
+
+	$ clojure -M:rdf-validator --suite test1.sparql --endpoint data.ttl
+
+## Writing a validation suite
+
+To provide more structure you may want to collate your tests into suites.
+
+To do this you can put the files into a directory (`"src"`) with a manifest file `rdf-validator-suite.edn` at the root:
+
+	/your/validation/repo
+	  |---- deps.edn
+	  |---- src
+			  |---- rdf-validator-suite.edn
+			  |---- myorg
+					|---- mysuite
+						  |---- test1.sparql
+						  |---- test2.sparql
+
+The manifest should specify the suite name and the relative paths to the SPARQL files to include:
+
+```clojure
+{:suite-name ["myorg/mysuite/test1.sparql"
+			  "myorg/mysuite/test2.sparql"]}
+```
+
+You can also use the manifest to add labels and descriptions or to modularise and re-use tests. See the docs on [defining test suites](/docs/DEFINING_TEST_SUITES.md) for more.
+
+You can pass this suite as a command-line option:
+
+	$ clojure -M:rdf-validator --suite src --endpoint data.ttl
+
+Or record it in your `deps.edn` file:
+
+```clojure
+{:aliases ;; as above
+ :paths ["src"]}
+```
+
+This will mean your suite is included by default so you can omit that option when running the validator:
+
+	$ clojure -M:rdf-validator --endpoint data.ttl
+
+
+## Including other validation suites
+
+You can include third-party validation suites (and indeed share your own for others to build upon) using Clojure's [deps](https://clojure.org/guides/deps_and_cli) tool by adding them as dependencies to the `deps.edn` file. Clojure deps supports [various ways of fetching and resolving dependencies](https://clojure.org/reference/deps_and_cli#_dependencies) and putting them on the classpath, such as via git, maven packaged jars, or just dependencies at a `:local/root`.
+
+For example, we can include a specific version of the `qb` suite from [pmd-rdf-validations](https://github.com/Swirrl/pmd-rdf-validations) by extending your `deps.edn` to add a `:deps` key alongside the `:aliases`:
+
+```clojure
+{:aliases ;; as above
+ :deps
+ { swirrl/validations.qb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
+						  :sha "63479f200a7c3d1b0e63bc43b2617181644c846b"
+						  :deps/manifest :deps
+						  :deps/root "qb"}}}
+```
+
+The `Swirrl/pmd-rdf-validations.git` repository contains multiple suites, each defined as their own dep within the same repo.  The `:deps/root` key essentially lets us point to a specific sub-directory, here for the `"qb"` (data cube) validations.
 
 Once these are specified we can run them against a repository containing data cubes, e.g.
 
-    $ clojure -A:rdf-validator --endpoint http://some.domain/sparql/query
+	$ clojure -M:rdf-validator --endpoint http://some.domain/sparql/query
 
-Note that this command will first fetch the validation suite dependency, cache it locally for future use, and run all the validation suites
-we put on the classpath (here just the data cube validations).
-
-### Writing your own validation suites
-
-Validations can be supplied on the command line as just a directory of `.sparql` files, or specified on the JVMs classpath via your `deps.edn` file.
-
-Here we demonstrate writing a simple classpath suite, as it is the easiest way to manage suites of validations that can be included as libraries.  Other
-supported methods are described in the more detailed docs.
-
-To do this first add a `:paths ["src"]` key to your `deps.edn`:
-
-```clojure
- {:paths ["src"]
-  :deps {;; NOTE each dep here is a validation suite
-         swirrl/validations.qb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
-                                :sha "63479f200a7c3d1b0e63bc43b2617181644c846b"
-                                :deps/manifest :deps
-                                :deps/root "qb"}
-        }
- :aliases {:rdf-validator {:extra-deps { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
-                                                               :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
-                           :main-opts ["-m" "rdf-validator.core"]}
-                     }
-
- }
-```
-
-This essentially says when running the validator to include the `"src"` directory on the JVM's classpath.  Next create the suite with the following
-directory structure:
-
-    /your/validation/repo
-      |---- deps.edn
-      |---- src
-              |---- rdf-validator-suite.edn
-              |---- myorg
-                    |---- mysuite
-                          |---- test1.sparql
-                          |---- test2.sparql
-
-Then in the `rdf-validator-suite.edn` file which must be at a classpath root (i.e. at the root of the "src" directory) specify the suites name and the relative paths
-to the SPARQL files to include the suite, e.g.
-
-```clojure
-{
-  :suite-name ["myorg/mysuite/test1.sparql"
-               "myorg/mysuite/test2.sparql"]
-}
-```
-
-Next write your SPARQL validations and run like so:
-
-    $ clojure -A:rdf-validator --endpoint http://some.domain/sparql/query
-
-[More on defining test suites](/docs/DEFINING_TEST_SUITES.md)
-
-### Writing SPARQL validations
-
-Validations are written as either SPARQL `SELECT` queries which should find and return validation failures, or
-ASK queries which fail when returning `false`.
-
-We recommend prefering the `SELECT` style as they provide more information to users on what went wrong.  For example
-this query is a port of IC-1 from the RDF Datacube spec into `SELECT` style.
-
-It will return any `qb:Observation`s that are not also in a `qb:dataSet`:
-
-```sparql
-PREFIX qb:      <http://purl.org/linked-data/cube#>
-
-SELECT (?obs AS ?obsWithNoDataset)
-WHERE {
-  {
-    # Check observation has a data set
-    ?obs a qb:Observation .
-    FILTER NOT EXISTS { ?obs qb:dataSet ?dataset1 . }
-  }
-}
-```
-
-Some more example `SELECT` queries for validating RDF Data cubes can be [found here](https://github.com/Swirrl/pmd-rdf-validations/tree/master/pmd-qb/src/swirrl/validations/pmd-qb)
-
-Additionally RDF Validator supports an advanced feature which usually needn't be used, to pre-process queries with [selmer](https://github.com/yogthos/Selmer) by replacing "handlebars like" variables (e.g `{{dataset-uri}}`) with any bound `--variables` provided via an `.edn` map of bindings, e.g.
-
-```clojure
-{:dataset-uri "http://my.domain/data/my-dataset"}
-```
-
-[More on writing test cases](/docs/WRITING_TEST_CASES.md)
-
-## Usage
-
-[More on command line options and usage](/docs/USAGE.md)
+Note that this command will first fetch the validation suite dependency, cache it locally for future use, and run all the validation suites we put on the classpath (here just the data cube validations).
 
 ## License
 
 Copyright © 2018 Swirrl IT Ltd.
 
-Distributed under the Eclipse Public License either version 1.0 or (at
-your option) any later version.
+Distributed under the Eclipse Public License either version 1.0 or (at your option) any later version.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once clojure is installed you can create a new directory and add a `deps.edn` fi
  {:rdf-validator
   {:extra-deps
    { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
-                           :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
+                           :sha "4a81411e713adbaad12b32bc800e8bef7175d93e"}}
    :main-opts ["-m" "rdf-validator.core"]}}}
 ```
 
@@ -110,7 +110,7 @@ For example, we can include a specific version of the `qb` suite from [pmd-rdf-v
 {:aliases ;; as above
  :deps
  { swirrl/validations.qb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
-                          :sha "63479f200a7c3d1b0e63bc43b2617181644c846b"
+                          :sha "b8c6f8fcee9ed7e00f6b5aad4d691b441cd5428b"
                           :deps/manifest :deps
                           :deps/root "qb"}}}
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Simple runner for RDF test cases & validations.
 
-RDF Validator runs a collection of test cases against a SPARQL endpoint. The endpoint can be either a HTTP(s) SPARQL endpoint or a file or directory of RDF files on disk. Test cases can be specified as either a SPARQL query file containing either
+RDF Validator runs a collection of test cases against a SPARQL endpoint. The endpoint can be either a HTTP(s) SPARQL endpoint or a file or directory of RDF files on disk. Test cases can be specified as either a single SPARQL query file containing either
 an `ASK` or a `SELECT` query, or a suite of such files with a suite manifest.
 
 Main features:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once clojure is installed you can create a new directory and add a `deps.edn` fi
  {:rdf-validator
   {:extra-deps
    { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
-						   :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
+                           :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
    :main-opts ["-m" "rdf-validator.core"]}}}
 ```
 
@@ -40,15 +40,15 @@ The clojure cli tool will fetch the application (so you won't need to `git clone
 
 For example, to run a sparql test against a remote endpoint you can do:
 
-	$ clojure -M:rdf-validator --suite mytest.sparql --endpoint http://my/sparql/endpoint
+    $ clojure -M:rdf-validator --suite mytest.sparql --endpoint http://my/sparql/endpoint
 
 You can also have the validator load-up an in-memory sparql endpoint from a RDF file:
 
-	$ clojure -M:rdf-validator --suite mytest.sparql --endpoint mycube.ttl
+    $ clojure -M:rdf-validator --suite mytest.sparql --endpoint mycube.ttl
 
 Or by recursing through a directory tree of RDF files:
 
-	$ clojure -M:rdf-validator --suite mytest.sparql --endpoint /path/to/rdf
+    $ clojure -M:rdf-validator --suite mytest.sparql --endpoint /path/to/rdf
 
 You can see more examples in the docs on [command-line usage](/docs/USAGE.md).
 
@@ -58,7 +58,7 @@ Validations are written as SPARQL queries. We recommend that you write `SELECT` 
 
 You can pass your `.sparql` files to the validator with a command-line option (here validating a file of RDF data):
 
-	$ clojure -M:rdf-validator --suite test1.sparql --endpoint data.ttl
+    $ clojure -M:rdf-validator --suite test1.sparql --endpoint data.ttl
 
 ## Writing a validation suite
 
@@ -66,27 +66,27 @@ To provide more structure you may want to collate your tests into suites.
 
 To do this you can put the files into a directory (`"src"`) with a manifest file `rdf-validator-suite.edn` at the root:
 
-	/your/validation/repo
-	  |---- deps.edn
-	  |---- src
-			  |---- rdf-validator-suite.edn
-			  |---- myorg
-					|---- mysuite
-						  |---- test1.sparql
-						  |---- test2.sparql
+    myvalidator
+    ├── deps.edn
+    └── src
+        ├── myorg
+        │   └── mysuite
+        │       ├── test1.sparql
+        │       └── test2.sparql
+        └── rdf-validator-suite.edn
 
 The manifest should specify the suite name and the relative paths to the SPARQL files to include:
 
 ```clojure
 {:suite-name ["myorg/mysuite/test1.sparql"
-			  "myorg/mysuite/test2.sparql"]}
+              "myorg/mysuite/test2.sparql"]}
 ```
 
 You can also use the manifest to add labels and descriptions or to modularise and re-use tests. See the docs on [defining test suites](/docs/DEFINING_TEST_SUITES.md) for more.
 
 You can pass this suite as a command-line option:
 
-	$ clojure -M:rdf-validator --suite src --endpoint data.ttl
+    $ clojure -M:rdf-validator --suite src --endpoint data.ttl
 
 Or record it in your `deps.edn` file:
 
@@ -97,7 +97,7 @@ Or record it in your `deps.edn` file:
 
 This will mean your suite is included by default so you can omit that option when running the validator:
 
-	$ clojure -M:rdf-validator --endpoint data.ttl
+    $ clojure -M:rdf-validator --endpoint data.ttl
 
 
 ## Including other validation suites
@@ -110,16 +110,16 @@ For example, we can include a specific version of the `qb` suite from [pmd-rdf-v
 {:aliases ;; as above
  :deps
  { swirrl/validations.qb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
-						  :sha "63479f200a7c3d1b0e63bc43b2617181644c846b"
-						  :deps/manifest :deps
-						  :deps/root "qb"}}}
+                          :sha "63479f200a7c3d1b0e63bc43b2617181644c846b"
+                          :deps/manifest :deps
+                          :deps/root "qb"}}}
 ```
 
 The `Swirrl/pmd-rdf-validations.git` repository contains multiple suites, each defined as their own dep within the same repo.  The `:deps/root` key essentially lets us point to a specific sub-directory, here for the `"qb"` (data cube) validations.
 
 Once these are specified we can run them against a repository containing data cubes, e.g.
 
-	$ clojure -M:rdf-validator --endpoint http://some.domain/sparql/query
+    $ clojure -M:rdf-validator --endpoint http://some.domain/sparql/query
 
 Note that this command will first fetch the validation suite dependency, cache it locally for future use, and run all the validation suites we put on the classpath (here just the data cube validations).
 

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -1,10 +1,8 @@
 # Compiling
 
-Rather than using via the [clojure CLI tools](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools) it
-is also possible to AOT compile the RDF Validator as an uberjar, and run with the incantation: `java -jar rdf-validator.jar`.
+Rather than using via the [clojure CLI tools](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools) it is also possible to AOT compile the RDF Validator as an uberjar, and run with the incantation: `java -jar rdf-validator.jar`.
 
-This has the small advantage that it reduces start up time a little, however it does also make it substantially harder to assemble dependencies via
-the command line tools.  Hence this mechanism is no longer recommended.
+This has the small advantage that it reduces start up time a little, however it does also make it substantially harder to assemble dependencies via the command line tools hence this mechanism is no longer recommended.
 
 To compile an uberjar though, you need to first install [leiningen](https://leiningen.org/) and then run:
 

--- a/docs/DEFINING_TEST_SUITES.md
+++ b/docs/DEFINING_TEST_SUITES.md
@@ -1,7 +1,6 @@
 # Defining test suites
 
-A test suite defines a group of tests to be run. A test suite can be created from a single test file or a directory containing test files as shown in the
-examples above. A test suite can also be defined within an EDN file that lists the tests it contains. The minimal form of this EDN file is:
+A test suite defines a group of tests to be run. You can call a the validator with a single file or a directory of files. A test suite can also be defined within an EDN file that lists the tests it contains. The minimal form of this EDN file is:
 
 ```clojure
 {
@@ -11,9 +10,7 @@ examples above. A test suite can also be defined within an EDN file that lists t
 }
 ```
 
-Each key in the top-level map defines a test suite and the corresponding value contains the suite definition. Each test definition in the associated
-list should be a path to a test file relative to the suite definition file. The type and name of each test is derived from the test file name. These
-can be stated explicitly by defining tests within a map:
+Each key in the top-level map defines a test suite and the corresponding value contains the suite definition. Each test definition in the associated list should be a path to a test file relative to the suite definition file. The type and name of each test is derived from the test file name. These can be stated explicitly by defining tests within a map:
 
 ```clojure
 {
@@ -27,8 +24,9 @@ can be stated explicitly by defining tests within a map:
 }
 ```
 
-When defining test definitions explicitly, only the `:source` key is required, the type and name will be derived from the test file name if not
-provided. The two styles of defining tests can be combined within a test suite definition as defined above.
+When defining test definitions explicitly, only the `:source` key is required, the type and name will be derived from the test file name if not provided.
+
+As described in the documentation on [writing test cases](/doc/WRITING_TEST_CASES.md), you can choose between `ASK` and `SELECT` queries. Both types can be combined within a test suite definition.
 
 ## Combining test suites
 
@@ -68,7 +66,7 @@ same suite file. For example given two test files:
 
 this is valid as long as `suite1.edn` is provided as a suite whenever `suite2.edn` is required e.g.
 
-    clojure -A:rdf-validator --endpoint data.ttl --suite suite1.edn --suite suite2.edn
+    $ clojure -M:rdf-validator --endpoint data.ttl --suite suite1.edn --suite suite2.edn
 
 ### Running individual suites
 
@@ -87,8 +85,8 @@ to the command-line invocation e.g.
  :suite3 ["test5.sparql"]}
 ```
 
-    clojure -A:rdf-validator --endpoint data.ttl --suite tests.edn suite2 suite3
+    $ clojure -M:rdf-validator --endpoint data.ttl --suite tests.edn suite2 suite3
 
 This will execute the tests defined within `suite2` and `suite3` within `tests.edn`.
 
-    $ clojure -A:rdf-validator --endpoint data.ttl --suite bad_predicate.sparql --variables variables.edn
+    $ clojure -M:rdf-validator --endpoint data.ttl --suite bad_predicate.sparql --variables variables.edn

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,30 +1,33 @@
 # Usage (command line options)
 
-RDF Validator runs a collection of test cases against a SPARQL endpoint. The endpoint can be either a HTTP(s) SPARQL
-endpoint or a file or directory on disk. Test cases can be specified as either a SPARQL query file, or a directory
-of such files.
+RDF Validator runs a collection of test cases against a SPARQL endpoint.
 
-The repository contains versions of the well-formed cube validation queries defined in the [RDF data cube specification](https://www.w3.org/TR/vocab-data-cube/#wf).
-These are defined as SPARQL SELECT queries rather than the ASK queries defined in the specification to enable more detailed error reporting.
+The endpoint can be either a HTTP(s) SPARQL endpoint or a file or directory on disk.
 
-To run these tests against a local SPARQL endpoint:
+Test cases can be specified as either a SPARQL query file, or a directory of such files.
 
-    $ clojure -A:rdf-validator --endpoint http://localhost/sparql/query --suite ./queries
+To run a directory of tests against a SPARQL endpoint:
 
-This will run all test cases in the queries directory against the endpoint. Test cases can be run individually:
+	$ clojure -A:rdf-validator --endpoint http://localhost/sparql/query --suite ./queries
 
-    $ clojure -A:rdf-validator --endpoint http://localhost/sparql/query --suite ./queries/01_SELECT_Observation_Has_At_Least_1_Dataset.sparql
+To run test cases individually:
 
-SPARQL endpoints can also be loaded from a file containing serialised RDF triples:
+	$ clojure -A:rdf-validator --endpoint http://localhost/sparql/query --suite ./queries/01_SELECT_Observation_Has_At_Least_1_Dataset.sparql
 
-    $ clojure -A:rdf-validator --endpoint data.ttl --suite ./queries
+Multiple individual test cases can be specified:
 
-Multiple test cases can be specified:
+	$ clojure -A:rdf-validator --endpoint http://localhost/sparql/query --suite test1.sparql --suite test2.sparql
 
-    $ clojure -A:rdf-validator --endpoint data.ttl --suite test1.sparql --suite test2.sparql
+To load an in-memory SPARQL endpoints from a file containing serialised RDF triples:
+
+	$ clojure -A:rdf-validator --endpoint data.ttl --suite ./queries
+
+You can also load data from a directory of RDF files:
+
+	$ clojure -A:rdf-validator --endpoint ./data --suite ./queries
 
 The RDF dataset can also be specified:
 
-    $ clojure -A:rdf-validator --endpoint data.ttl --graph http://graph1 --graph http://graph2 --suite test1.sparql
+	$ clojure -A:rdf-validator --endpoint ./data --suite ./queries --graph http://graph1 --graph http://graph2
 
 Graphs are added a named graphs and included in the default graph.


### PR DESCRIPTION
Hopefully this helps explain a little better how to install and run the validator.

I think it's actually better to send people to the pmd-rdf-validations repo first as this is basically ready-to-use.

I've sought to highlight the main usage options as soon as possible (instead of having this be a footnote at the bottom).

I've also explained how to run sparql validations first before introducing the idea of git deps. Although git deps are a major selling point to this approach, I think it's necessary to start closer to where the audience is coming from - show them how to run their sparql - before introducing suites/ git deps etc. 